### PR TITLE
Feature enhancement for the AugAssign Nodetype and other fixes to correctly get read and write variables

### DIFF
--- a/sully/__init__.py
+++ b/sully/__init__.py
@@ -233,6 +233,11 @@ class TaintAnalysis(ast.NodeVisitor):
                 func_id = (node.func.value.id, node.func.attr)
                 self.functions[func_id].add(node.lineno)
 
+            # If the function is called on previously declared value then
+            # value should be recorded in the read_lines.
+            if isinstance(node.func.value.ctx, ast.Load):
+                self.read_lines[self.get_id(node.func.value)].add(node.lineno)
+
             # Assume function calls on objects modify data
             self.write_lines[self.get_id(node.func.value)].add(node.lineno)
 

--- a/sully/__init__.py
+++ b/sully/__init__.py
@@ -169,7 +169,8 @@ class TaintAnalysis(ast.NodeVisitor):
         self.visit(node.value)
 
         for target in node.targets:
-            self.visit(target)
+            if isinstance(target, ast.Subscript):
+                self.visit(target)
             self.write_lines[self.get_id(target)].add(node.lineno)
 
             # Record type of each Variable

--- a/sully/__init__.py
+++ b/sully/__init__.py
@@ -167,6 +167,13 @@ class TaintAnalysis(ast.NodeVisitor):
             self.write_lines[self.get_id(target)].add(node.lineno)
             self.check_add_taint(node.value, target)
 
+    # Record read and write to a given value
+    def visit_AugAssign(self, node):
+        self.visit(node.value)
+        self.read_lines[self.get_id(node.target)].add(node.lineno)
+        self.write_lines[self.get_id(node.target)].add(node.lineno)
+        self.check_add_taint(node.value, node.target)
+
     # Copy the taint for comparison operators
     def visit_Compare(self, node):
         # XXX We only handle a single comparison

--- a/sully/__init__.py
+++ b/sully/__init__.py
@@ -100,10 +100,12 @@ class TaintAnalysis(ast.NodeVisitor):
 
         # Initialize lists to track usage
         self.read_lines = defaultdict(set)
+        self.stores = defaultdict(int)
         self.write_lines = defaultdict(set)
         self.taint_exprs = set()
         self.tainted_by = defaultdict(list)
         self.functions = defaultdict(set)
+        self.variableTypes = defaultdict(set)
 
         # Start visiting the root of the function's AST
         self.func_ast = ParentTransformer().visit(func_ast)
@@ -159,12 +161,20 @@ class TaintAnalysis(ast.NodeVisitor):
     def visit(self, node):
         super(TaintAnalysis, self).visit(node)
 
+    def visit_Subscript(self, node):
+        self.visit(node.value)
+
     # Record a write to a given value
     def visit_Assign(self, node):
         self.visit(node.value)
 
         for target in node.targets:
+            self.visit(target)
             self.write_lines[self.get_id(target)].add(node.lineno)
+
+            # Record type of each Variable
+            if self.get_id(target) not in self.variableTypes:
+                self.variableTypes[self.get_id( target)] = type(node.value)
             self.check_add_taint(node.value, target)
 
     # Record read and write to a given value
@@ -210,7 +220,6 @@ class TaintAnalysis(ast.NodeVisitor):
     def visit_Attribute(self, node):
         var = (self.get_id(node.value), node.attr)
         self.read_lines[var].add(node.lineno)
-
         self.visit(node.value)
 
     # Record a read of a simple variable
@@ -219,6 +228,10 @@ class TaintAnalysis(ast.NodeVisitor):
         # we will capture these when we visit Attribute nodes
         if isinstance(node.ctx, ast.Load) and node.id != 'self':
             self.read_lines[node.id].add(node.lineno)
+
+        # Record line number of each variable when it is declared
+        if isinstance(node.ctx, ast.Store):
+            self.stores[str(node.id)] = node.lineno
 
     # Record reads and writes from functions called within our function
     def visit_Call(self, node):
@@ -233,10 +246,10 @@ class TaintAnalysis(ast.NodeVisitor):
                 func_id = (node.func.value.id, node.func.attr)
                 self.functions[func_id].add(node.lineno)
 
-            # If the function is called on previously declared value then
-            # value should be recorded in the read_lines.
-            if isinstance(node.func.value.ctx, ast.Load):
-                self.read_lines[self.get_id(node.func.value)].add(node.lineno)
+                # If the function is called on previously declared value then
+                # value should be recorded in the read_lines.
+                if isinstance(node.func.value.ctx, ast.Load):
+                    self.read_lines[self.get_id(node.func.value)].add(node.lineno)
 
             # Assume function calls on objects modify data
             self.write_lines[self.get_id(node.func.value)].add(node.lineno)

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -66,7 +66,7 @@ def test_array_read(taint):
     assert taint.read_lines['y'] == set([3, 4, 5, 6, 7])
 
 def test_array_write(taint):
-    assert taint.write_lines['y'] == set([2])
+    assert taint.write_lines['y'] == set([2, 4])
 
 def test_parameter_read(taint):
     assert taint.read_lines['a'] == set([14])


### PR DESCRIPTION
It was not giving a correct list of variables in read_lines and write_line. 
Add a function to correctly record read and write variables for "sum += 1" .

Signed-off-by: Akash Desai <akashdesai2007@gmail.com>